### PR TITLE
[FEAT] 변경된 Layout에서 동작하는 Snackbar 컴포넌트 구현

### DIFF
--- a/components/Oauth/KakaoLoginButtonV2.tsx
+++ b/components/Oauth/KakaoLoginButtonV2.tsx
@@ -1,15 +1,53 @@
 import { KakaoSDK } from '@/components/Oauth/KakaoSDK';
 import CommonFont from '@/components/common/Font';
+import { useControlSnackbarV2 } from '@/hook/useControlSnackbarV2';
 import { useKakaoLogin } from '@/hook/useKakaoLogin';
+
 import styled from '@emotion/styled';
-import { Snackbar } from '@mui/material';
 import Image from 'next/image';
+import { useEffect } from 'react';
 
 export default function KakaoLoginButtonV2() {
   const { open, isLoading, setIsLoading, isError, setIsError } =
     useKakaoLogin();
+  const { openSnackbar, closeSnackbar } = useControlSnackbarV2();
 
-  console.log(isLoading, isError);
+  useEffect(() => {
+    if (isLoading) {
+      openSnackbar({
+        message: '로그인 중입니다.',
+        autoHideDuration: 3 * 1000,
+        anchorOrigin: {
+          vertical: 'bottom',
+          horizontal: 'center',
+        },
+        onClose: () => {
+          setIsLoading(false);
+          closeSnackbar();
+        },
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading]);
+
+  useEffect(() => {
+    if (isError) {
+      openSnackbar({
+        message: '로그인 오류가 발생했습니다. 다시 시도해 주세요.',
+        autoHideDuration: 3000,
+        anchorOrigin: {
+          vertical: 'bottom',
+          horizontal: 'center',
+        },
+        onClose: () => {
+          setIsError(false);
+          closeSnackbar();
+        },
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isError]);
+
   return (
     <>
       <KakaoSDK />
@@ -19,52 +57,6 @@ export default function KakaoLoginButtonV2() {
           카카오톡 로그인
         </CommonFont>
       </S.KakaoLoginButtonContainer>
-      {isLoading && (
-        <Snackbar
-          open={isLoading}
-          message={'로그인 중입니다.'}
-          autoHideDuration={3000}
-          anchorOrigin={{
-            vertical: 'bottom',
-            horizontal: 'center',
-          }}
-          ContentProps={{
-            sx: {
-              justifyContent: 'center',
-            },
-          }}
-          onClose={() => {
-            setIsError(false);
-            setIsLoading(false);
-          }}
-          sx={{
-            bottom: '72px',
-          }}
-        />
-      )}
-      {isError && (
-        <Snackbar
-          open={isError}
-          message={'로그인 오류가 발생했습니다. 다시 시도해 주세요.'}
-          autoHideDuration={3000}
-          anchorOrigin={{
-            vertical: 'bottom',
-            horizontal: 'center',
-          }}
-          ContentProps={{
-            sx: {
-              justifyContent: 'center',
-            },
-          }}
-          onClose={() => {
-            setIsError(false);
-            setIsLoading(false);
-          }}
-          sx={{
-            bottom: '72px',
-          }}
-        />
-      )}
     </>
   );
 }

--- a/components/common/CheckButton/index.tsx
+++ b/components/common/CheckButton/index.tsx
@@ -1,6 +1,7 @@
 import FlexBox from '@/components/common/FlexBox';
 import CommonIcon from '@/components/common/Icon';
 import CommonFont from '@/components/common/Font';
+import CheckButtonStyled from '@/components/common/CheckButton/style';
 import type { FontSizeKeys } from '@/styles/typography';
 import type { CSSProperties, PropsWithChildren } from 'react';
 
@@ -34,11 +35,11 @@ export default function CommonCheckButton({
   };
 
   return (
-    <button onClick={handleOnClick}>
+    <CheckButtonStyled.Button onClick={handleOnClick}>
       <FlexBox gap={gap}>
         <CommonIcon iconName={iconName} />
         <CommonFont fontSize={fontSize}>{children}</CommonFont>
       </FlexBox>
-    </button>
+    </CheckButtonStyled.Button>
   );
 }

--- a/components/common/CheckButton/style.ts
+++ b/components/common/CheckButton/style.ts
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+
+const CheckButtonStyled = {
+  Button: styled.button`
+    display: flex;
+  `,
+};
+
+export default CheckButtonStyled;

--- a/components/commonV2/Layout/index.tsx
+++ b/components/commonV2/Layout/index.tsx
@@ -5,6 +5,7 @@ import HeadMeta, { HeadMetaProps } from '@/components/HeadMeta';
 import CommonNewBottomNavigatior from '@/components/commonV2/NavigatorBar';
 import { useControlModalV2 } from '@/hook/useControlModalV2';
 
+import SnackbarV2 from '@/components/commonV2/SnackbarV2';
 import { PropsWithChildren, useEffect, useState } from 'react';
 
 const useMobileFullView = () => {
@@ -41,6 +42,7 @@ export default function LayoutV2({
 }: LayoutV2Props) {
   const vh = useMobileFullView();
   const { modalState } = useControlModalV2();
+
   return (
     <S.LayoutBody vh={vh}>
       <HeadMeta {...headMetaProps} />
@@ -48,6 +50,7 @@ export default function LayoutV2({
         <S.LayoutContent>{children}</S.LayoutContent>
         {showBottomNavigator && <CommonNewBottomNavigatior />}
         {modalState.isOpen && <ModalV2 />}
+        <SnackbarV2 />
       </S.LayoutMaxMin>
     </S.LayoutBody>
   );

--- a/components/commonV2/SnackbarV2/index.tsx
+++ b/components/commonV2/SnackbarV2/index.tsx
@@ -1,0 +1,32 @@
+import { useControlSnackbarV2 } from '@/hook/useControlSnackbarV2';
+import Snackbar from '@mui/material/Snackbar';
+
+export default function SnackbarV2() {
+  const { snackbarState } = useControlSnackbarV2();
+
+  const vertical = snackbarState.anchorOrigin?.vertical;
+
+  /**
+   * TODO: 위에서 나타나는 toast를 사용할 떄 해당 px 값을 변경
+   * 72px 말고 다른 값을 넣고 싶다면 openSnackbar 함수에서 sx로 넣어주면 됩니다.
+   */
+
+  const top = vertical === 'top' ? '72px' : undefined;
+  const bottom = vertical === 'bottom' ? '72px' : undefined;
+
+  return (
+    <Snackbar
+      sx={{
+        position: 'absolute',
+        top,
+        bottom,
+      }}
+      ContentProps={{
+        sx: {
+          justifyContent: 'center',
+        },
+      }}
+      {...snackbarState}
+    />
+  );
+}

--- a/hook/useControlSnackbarV2.ts
+++ b/hook/useControlSnackbarV2.ts
@@ -1,0 +1,40 @@
+import { SnackbarProps } from '@mui/material';
+import { atom, useAtom } from 'jotai';
+import { useEffect } from 'react';
+
+const snackbarAtomDefault: SnackbarProps = {
+  open: false,
+  message: null,
+  autoHideDuration: undefined,
+  anchorOrigin: {
+    vertical: 'bottom',
+    horizontal: 'center',
+  },
+};
+
+const snackbarAtom = atom<SnackbarProps>(snackbarAtomDefault);
+
+export const useControlSnackbarV2 = () => {
+  const [snackbarState, setSnackbarState] = useAtom(snackbarAtom);
+
+  const openSnackbar = (options: SnackbarProps) => {
+    setSnackbarState((pre) => ({ ...pre, ...options, open: true }));
+  };
+  const closeSnackbar = () => {
+    setSnackbarState((pre) => ({ ...pre, open: false }));
+  };
+
+  const resetSnackbar = () => {
+    setSnackbarState({ ...snackbarAtomDefault });
+  };
+
+  useEffect(() => {
+    return () => resetSnackbar();
+  }, []);
+
+  return {
+    snackbarState,
+    openSnackbar,
+    closeSnackbar,
+  };
+};


### PR DESCRIPTION
### 사용법

- 변경된 `ModalV2` 과 마찬가지로 `LayoutV2` Component에서 `SnackbarV2` 를 렌더링합니다.
- `fixed`가 아니라 `absolute`로 동작합니다.
- 열고 닫을 때는 `useControlSnackbarV2` hook을 통해서 열고 닫습니다.
- MUI `Snackbar`에 넘겨주고자 하는 props를 `openSnackbar` 함수의 첫번째 인자로 넣어줍니다.
- `onClose` props에서 `closeSnackbar` 함수를 호출해줍니다.

🔸 KakaoLoginButtonV2 컴포넌트를 참고하시면 됩니다.

> 현재 컴포넌트가 unmounted 되었을 때 resetSnackbar 함수를 호출해주도록 구현하였습니다.