### PR TITLE
[FIX] search page redirect 에러 해결

### DIFF
--- a/hook/useMyPortFolio.ts
+++ b/hook/useMyPortFolio.ts
@@ -2,8 +2,11 @@ import { useMyPortFolioQuery } from '@/hook/useQueryHook/useMyPortFolioQuery';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
+const EMPTY_REDIRECT_EXCEPTION_URLS = ['/search'];
+
 export const useMyPortFolio = () => {
   const router = useRouter();
+  const { pathname } = router;
   const { data, status, isLoading, isFetching } = useMyPortFolioQuery();
   const redirectEmpty = () => router.push('/empty');
   const myPortFolioData = data?.data.data;
@@ -12,17 +15,18 @@ export const useMyPortFolio = () => {
     const hasNotPortFolio =
       !isLoading && !isFetching && status === 'success' && !myPortFolioData;
     const isError = status === 'error';
+    const isExceptionURL = EMPTY_REDIRECT_EXCEPTION_URLS.includes(pathname);
 
     if (isError) {
       router.push('500');
       return;
     }
 
-    if (hasNotPortFolio) {
+    if (hasNotPortFolio && !isExceptionURL) {
       redirectEmpty();
       return;
     }
-  }, [status, myPortFolioData, isLoading, isFetching]);
+  }, [status, myPortFolioData, isLoading, isFetching, pathname]);
 
   return {
     myPortFolioData,


### PR DESCRIPTION
useMyPortfolio hook을 사용하는 컴포넌트의 pathname이 '/search' 일 경우 '/empty'로 리다이렉트 되지 않도록 코드를 변경