### PR TITLE
[FEAT] 메인페이지 API 원화로 모두 변경, 소득세 관련 로직 변경

### DIFF
--- a/components/Chart/index.tsx
+++ b/components/Chart/index.tsx
@@ -18,10 +18,9 @@ ChartJS.register(CategoryScale, LinearScale, BarElement, ChartDataLabels);
 
 export default function AnnualDividendBarChart() {
   const theme = useTheme();
-  const { annualDividendExchangeWithSimpleData } = useAnnualDividend();
+  const { annualDividendSimpleKRData } = useAnnualDividend();
 
-  const monthlyDividends =
-    annualDividendExchangeWithSimpleData?.monthlyDividends;
+  const monthlyDividends = annualDividendSimpleKRData?.monthlyDividends;
   const showChartDividendDatas = createShowChartDividendDatas(monthlyDividends);
 
   if (showChartDividendDatas) {

--- a/components/Chart/utils.ts
+++ b/components/Chart/utils.ts
@@ -9,6 +9,10 @@ export const getShortCurrencyKRByMinusNumber = (value: number) => {
   const TEN_BLIILON = 10000000000;
   const absoluteValue = Math.abs(value);
 
+  if (absoluteValue === 0) {
+    return '0';
+  }
+
   if (absoluteValue < 10000) {
     return Math.floor(value).toLocaleString('ko-kr');
   }
@@ -20,10 +24,15 @@ export const getShortCurrencyKRByMinusNumber = (value: number) => {
 
   /** 100억 미만 */
   if (absoluteValue < TEN_BLIILON) {
-    return Math.floor(value / (10000 * 10000)) + '억';
+    return [
+      Math.floor(absoluteValue / (10000 * 10000)) * -1 + '억',
+      Math.floor((absoluteValue % (10000 * 10000)) / 10000) + '만',
+    ]
+      .join(' ')
+      .trim();
   }
 
-  return '99억';
+  return '-99억';
 };
 
 export const getShortCurrencyKRByPlusNumber = (value: number) => {
@@ -44,13 +53,47 @@ export const getShortCurrencyKRByPlusNumber = (value: number) => {
 
   /** 100억 미만 */
   if (value < TEN_BLIILON) {
+    const upperMillion = Math.floor(value / (10000 * 10000));
+    const upperTenThousand = Math.floor((value % (10000 * 10000)) / 10000);
+
+    console.log(upperMillion);
+
+    return [
+      upperMillion + '억',
+      upperTenThousand > 0 ? `${upperTenThousand}만` : '',
+    ]
+      .join(' ')
+      .trim();
+  }
+
+  return '99억 9999만';
+};
+
+export const getShortCurrencyDividendChartKR = (value: number) => {
+  /** 최대 100억 */
+  const TEN_BLIILON = 10000000000;
+
+  if (value <= 0) return '';
+
+  // 1만 미만
+  if (value < 10000) {
+    return Math.floor(value).toLocaleString('ko-kr');
+  }
+
+  // 1억 미만
+  if (value < 10000 * 10000) {
+    return Math.floor(value / 10000) + '만';
+  }
+
+  /** 100억 미만 */
+  if (value < TEN_BLIILON) {
     return Math.floor(value / (10000 * 10000)) + '억';
   }
 
   return '99억';
 };
 
-const createShowChartDividendDatas = (
+export const createShowChartDividendDatas = (
   dividendDatas: MonthlyDividends | undefined,
 ) => {
   if (!dividendDatas) return;
@@ -79,36 +122,4 @@ const createShowChartDividendDatas = (
   );
 
   return showChartDividendDatas;
-};
-
-export {
-  // formatChartValue,
-  createShowChartDividendDatas,
-};
-
-// 차트는 0인 경우 '' 빈 문자열을 보여줘야한다.
-// 차트가 아닌 경우에는 toLocaleString(); 같은것들을 통해서 toFixed같은걸 적용해서 99억 이상인 경우에도 보여줘야 한다. 999조 까지만 보여줘야할 것 같다.
-
-export const getShortCurrencyDividendChartKR = (value: number) => {
-  /** 최대 100억 */
-  const TEN_BLIILON = 10000000000;
-
-  if (value <= 0) return '';
-
-  // 1만 미만
-  if (value < 10000) {
-    return Math.floor(value).toLocaleString('ko-kr');
-  }
-
-  // 1억 미만
-  if (value < 10000 * 10000) {
-    return Math.floor(value / 10000) + '만';
-  }
-
-  /** 100억 미만 */
-  if (value < TEN_BLIILON) {
-    return Math.floor(value / (10000 * 10000)) + '억';
-  }
-
-  return '99억';
 };

--- a/components/List/DetailInformationList/index.tsx
+++ b/components/List/DetailInformationList/index.tsx
@@ -8,21 +8,22 @@ import AnnualDividendModal from '@/components/common/Modal/AnnualDividendModal';
 import type { BadgeDetailText } from '@/mocks';
 
 export default function DetailInformationList() {
-  const { annualDividendExchangeData, annualDividendExchangeWithSimpleData } =
-    useAnnualDividend();
+  const {
+    // annualDividendSimpleKRData,
+    annualDividendTaxKRData,
+    annualDividendSimpleKRData,
+  } = useAnnualDividend();
 
   const detailInformationData = {
-    annualDividend: `${
-      annualDividendExchangeWithSimpleData?.annualDividend || 0
-    }`,
+    annualDividend: `${annualDividendSimpleKRData?.annualDividend || 0}`,
     dividendPriceRatio: `${
-      annualDividendExchangeWithSimpleData?.dividendPriceRatio.toFixed(2) || 0
+      annualDividendSimpleKRData?.dividendPriceRatio.toFixed(2) || 0
     }%`,
-    paidTax: annualDividendExchangeWithSimpleData?.paidTax
-      ? `${annualDividendExchangeWithSimpleData?.paidTax}`
+    paidTax: annualDividendSimpleKRData?.paidTax
+      ? `${annualDividendSimpleKRData?.paidTax}`
       : '없음',
-    unPaidTax: annualDividendExchangeWithSimpleData?.unPaidTax
-      ? `${annualDividendExchangeWithSimpleData?.unPaidTax} 예상`
+    unPaidTax: annualDividendSimpleKRData?.unPaidTax
+      ? `${annualDividendSimpleKRData?.unPaidTax} 예상`
       : '없음',
   };
 
@@ -59,7 +60,7 @@ export default function DetailInformationList() {
           ),
           value: (
             <CommonFont fontSize="body1" fontWeight="bold" color="point_red01">
-              {annualDividendExchangeWithSimpleData?.dividendPriceRatio}%
+              {annualDividendSimpleKRData?.dividendPriceRatio}%
             </CommonFont>
           ),
         },
@@ -76,7 +77,7 @@ export default function DetailInformationList() {
           ),
           value: (
             <CommonFont fontSize="body1" fontWeight="bold" color="point_red01">
-              {annualDividendExchangeWithSimpleData?.dividendYieldRatio}%
+              {annualDividendSimpleKRData?.dividendYieldRatio}%
             </CommonFont>
           ),
         },
@@ -101,7 +102,7 @@ export default function DetailInformationList() {
           ),
           value: (
             <CommonFont fontSize="body1" fontWeight="bold" color="point_blue02">
-              {annualDividendExchangeData?.paidTax}
+              {annualDividendTaxKRData?.paidTax}
             </CommonFont>
           ),
         },
@@ -139,7 +140,7 @@ export default function DetailInformationList() {
           ),
           value: (
             <CommonFont fontSize="body1" fontWeight="bold" color="point_blue02">
-              {annualDividendExchangeData?.unPaidTax} 예상
+              {annualDividendTaxKRData?.unPaidTax} 예상
             </CommonFont>
           ),
         },

--- a/components/List/ScheduleList/index.tsx
+++ b/components/List/ScheduleList/index.tsx
@@ -1,15 +1,11 @@
-import {
-  // useMonthlyCalanderDividendExchangeQuery,
-  useMonthlyCalanderDividendKRQuery,
-} from '@/hook/useQueryHook/useMonthlyCalanderDividendQuery';
+import { useMonthlyCalanderDividendKRWithSimpleQuery } from '@/hook/useQueryHook/useMonthlyCalanderDividendQuery';
 import CommonFont from '@/components/common/Font';
 
 import StockAvatar from '@/components/common/StockAvatar';
 import { Box, List, ListItem, ListItemText, ListItemIcon } from '@mui/material';
 
 export function ScheduleList() {
-  // const { data } = useMonthlyCalanderDividendExchangeQuery();
-  const { data } = useMonthlyCalanderDividendKRQuery();
+  const { data } = useMonthlyCalanderDividendKRWithSimpleQuery();
 
   if (data?.success === true && !data?.data.length) {
     return (

--- a/components/List/ScheduleList/index.tsx
+++ b/components/List/ScheduleList/index.tsx
@@ -1,11 +1,15 @@
-import { useMonthlyCalanderDividendExchangeQuery } from '@/hook/useQueryHook/useMonthlyCalanderDividendQuery';
+import {
+  // useMonthlyCalanderDividendExchangeQuery,
+  useMonthlyCalanderDividendKRQuery,
+} from '@/hook/useQueryHook/useMonthlyCalanderDividendQuery';
 import CommonFont from '@/components/common/Font';
 
 import StockAvatar from '@/components/common/StockAvatar';
 import { Box, List, ListItem, ListItemText, ListItemIcon } from '@mui/material';
 
 export function ScheduleList() {
-  const { data } = useMonthlyCalanderDividendExchangeQuery();
+  // const { data } = useMonthlyCalanderDividendExchangeQuery();
+  const { data } = useMonthlyCalanderDividendKRQuery();
 
   if (data?.success === true && !data?.data.length) {
     return (

--- a/components/portfolio/portfolioSections/ChartSection/index.tsx
+++ b/components/portfolio/portfolioSections/ChartSection/index.tsx
@@ -12,19 +12,26 @@ import Modal from '@/components/common/Modal';
 import { CenterModalV2 } from '@/components/commonV2/ModalV2/CenterModal';
 
 export default function ChartSection() {
-  const { annualDividendExchangeWithSimpleData } = useAnnualDividend();
+  const { annualDividendSimpleKRData } = useAnnualDividend();
   const { palette } = useEmotionTheme();
 
+  const isPlusDividendChange =
+    annualDividendSimpleKRData?.dividendChange &&
+    parseInt(annualDividendSimpleKRData?.dividendChange) > 0
+      ? true
+      : false;
+
   const chartSectionTexts = {
-    title: annualDividendExchangeWithSimpleData?.thisMonthDividend || '0원',
-    subTitle: annualDividendExchangeWithSimpleData?.dividendChange
-      ? `지난 배당 대비 ${annualDividendExchangeWithSimpleData?.dividendChange}%`
+    title: annualDividendSimpleKRData?.thisMonthDividend || '0원',
+    subTitle: annualDividendSimpleKRData?.dividendChange
+      ? `지난 배당 대비 ${
+          isPlusDividendChange ? '+' : ''
+        }${annualDividendSimpleKRData?.dividendChange}`
       : '',
     isShowChart:
-      annualDividendExchangeWithSimpleData?.monthlyDividends &&
-      Object.keys(annualDividendExchangeWithSimpleData?.monthlyDividends)
-        .length &&
-      annualDividendExchangeWithSimpleData?.annualDividend
+      annualDividendSimpleKRData?.monthlyDividends &&
+      Object.keys(annualDividendSimpleKRData?.monthlyDividends).length &&
+      annualDividendSimpleKRData?.annualDividend
         ? true
         : false,
   };
@@ -83,12 +90,7 @@ export default function ChartSection() {
         <h1 style={{ paddingBottom: '6px' }}>{title}</h1>
         <CommonFont
           fontSize="body1"
-          color={
-            annualDividendExchangeWithSimpleData?.dividendChange &&
-            annualDividendExchangeWithSimpleData?.dividendChange > 0
-              ? 'point_red01'
-              : 'point_blue02'
-          }
+          color={isPlusDividendChange ? 'point_red01' : 'point_blue02'}
         >
           {subTitle}
         </CommonFont>

--- a/components/portfolio/portfolioSections/DetailStocksSection/index.tsx
+++ b/components/portfolio/portfolioSections/DetailStocksSection/index.tsx
@@ -27,7 +27,7 @@ export default function DetailStocksSection() {
         {data?.totalValueChange && parseInt(data?.totalValueChange) > 0
           ? `+${data?.totalValueChange}`
           : `${data?.totalValueChange || '0원'}`}
-        {`(${data?.totalValueChangeRate || 0}%)`}
+        {` (${data?.totalValueChangeRate || 0}%)`}
       </Typography>
       <MyStockList />
     </Section>

--- a/hook/useAnnualDividend.ts
+++ b/hook/useAnnualDividend.ts
@@ -1,19 +1,32 @@
 import {
   useAnnualDividendExchangeQuery,
+  useAnnualDividendTaxKRQuery,
   useAnnualDividendExchangeWithSimpleQuery,
-  useAnnualDividendQuery,
+  // useAnnualDividendQuery,
+  useAnnualDividendSimpleKRQuery,
+  useAnnualDividendKRQuery,
 } from '@/hook/useQueryHook/useAnnualDividendQuery';
 
 export const useAnnualDividend = () => {
-  const { data: annualDividendData, isLoading } = useAnnualDividendQuery();
+  // const { data: annualDividendData, isLoading: annualDividendDataIsLoading } =
+  //   useAnnualDividendQuery();
+  const { data: annualDividendKRData, isLoading } = useAnnualDividendKRQuery();
+
+  /** USD  */
   const { data: annualDividendExchangeData } = useAnnualDividendExchangeQuery();
   const { data: annualDividendExchangeWithSimpleData } =
     useAnnualDividendExchangeWithSimpleQuery();
 
+  /** KR  */
+  const { data: annualDividendTaxKRData } = useAnnualDividendTaxKRQuery();
+  const { data: annualDividendSimpleKRData } = useAnnualDividendSimpleKRQuery();
+
   return {
-    annualDividendData: annualDividendData?.data,
+    annualDividendData: annualDividendKRData?.data,
     annualDividendExchangeData,
     annualDividendExchangeWithSimpleData,
+    annualDividendTaxKRData,
+    annualDividendSimpleKRData,
     isLoading,
   };
 };

--- a/hook/useFormatPrice.ts
+++ b/hook/useFormatPrice.ts
@@ -10,6 +10,7 @@ export const useFormatPrice = () => {
   const { modeData } = useControlMode();
 
   const divideByTax = (price: number) => Math.floor(price * (85 / 100));
+  const getByTax = (price: number) => Math.floor(price * (15 / 100));
   const divideSimple = (price: number) =>
     price > 0
       ? getShortCurrencyKRByPlusNumber(Math.floor(price))
@@ -47,12 +48,40 @@ export const useFormatPrice = () => {
     return newPrice.toLocaleString('ko-kr') + '원';
   };
 
+  const getTaxByPriceWithSimple = (price: number) => {
+    let newPrice: number = Math.floor(price);
+
+    if (!taxData.isTax) {
+      return '0원';
+    }
+
+    if (taxData.isTax) {
+      newPrice = getByTax(price);
+    }
+
+    if (modeData.isSimple) {
+      return divideSimple(newPrice) + '원';
+    }
+
+    return newPrice.toLocaleString('ko-kr') + '원';
+  };
+
+  const getTaxByPrice = (price: number) => {
+    if (taxData.isTax) {
+      return getByTax(price).toLocaleString('ko-kr') + '원';
+    }
+    return '0원';
+  };
+
   return {
     divideByTax,
     divideSimple,
+    getByTax,
     getPrice,
     getPriceByTax,
     getPriceBySimple,
     getPriceByTaxWithSimple,
+    getTaxByPriceWithSimple,
+    getTaxByPrice,
   };
 };

--- a/hook/useQueryHook/queryKeys.ts
+++ b/hook/useQueryHook/queryKeys.ts
@@ -31,6 +31,11 @@ export const queryKeys = {
     exchangeRate?: number,
     isTax?: boolean | null,
   ) => ['monthlyCalanderDividend', isSimple, isTax, exchangeRate],
+  monthlyCalanderDividendKR: (
+    isSimple?: boolean | null,
+
+    isTax?: boolean | null,
+  ) => ['monthlyCalanderDividend', isSimple, isTax],
   popularStocks: () => ['popularStocks'],
   recentSearchWords: () => ['getRecentSearchWords'],
   searchedResults: (word: string, pageIndex: number) => [

--- a/hook/useQueryHook/queryKeys.ts
+++ b/hook/useQueryHook/queryKeys.ts
@@ -21,6 +21,11 @@ export const queryKeys = {
     exchangeRate?: number,
     isTax?: boolean | null,
   ) => ['annualDividend', isSimple, isTax, exchangeRate],
+  annualDividendKR: (isSimple?: boolean | null, isTax?: boolean | null) => [
+    'annualDividendKR',
+    isSimple,
+    isTax,
+  ],
   monthlyCalanderDividend: (
     isSimple?: boolean | null,
     exchangeRate?: number,

--- a/hook/useQueryHook/useAnnualDividendQuery.ts
+++ b/hook/useQueryHook/useAnnualDividendQuery.ts
@@ -162,7 +162,7 @@ export const useAnnualDividendTaxKRQuery = () => {
   const { exchangeRate } = useExchangeRate();
   const { taxData } = useControlTax();
 
-  const { divideByTax, getPriceByTax, getTaxByPrice } = useFormatPrice();
+  const { divideByTax, getPriceByTax, getPrice, getByTax } = useFormatPrice();
 
   const getQueryFunction = () => {
     const annualDividendFullData:
@@ -189,8 +189,8 @@ export const useAnnualDividendTaxKRQuery = () => {
         dividendChange: getPriceByTax(annualDividendData.dividendChange),
         monthlyDividends: newMonthlyDividends,
         annualDividend: getPriceByTax(annualDividendData.annualDividend),
-        paidTax: getTaxByPrice(annualDividendData.paidTax),
-        unPaidTax: getTaxByPrice(annualDividendData.unPaidTax),
+        paidTax: getPrice(getByTax(annualDividendData.paidTax)),
+        unPaidTax: getPrice(getByTax(annualDividendData.unPaidTax)),
         thisMonthDividend: getPriceByTax(annualDividendData.thisMonthDividend),
       };
     }
@@ -206,7 +206,7 @@ export const useAnnualDividendSimpleKRQuery = () => {
   const queryClient = useQueryClient();
   const { modeData } = useControlMode();
   const { taxData } = useControlTax();
-  const { divideByTax, getPriceByTaxWithSimple, getTaxByPriceWithSimple } =
+  const { divideByTax, getPriceByTaxWithSimple, getPriceBySimple, getByTax } =
     useFormatPrice();
 
   const getQueryFunction = () => {
@@ -236,8 +236,8 @@ export const useAnnualDividendSimpleKRQuery = () => {
         annualDividend: getPriceByTaxWithSimple(
           annualDividendData.annualDividend,
         ),
-        paidTax: getTaxByPriceWithSimple(annualDividendData.paidTax),
-        unPaidTax: getTaxByPriceWithSimple(annualDividendData.unPaidTax),
+        paidTax: getPriceBySimple(getByTax(annualDividendData.paidTax)),
+        unPaidTax: getPriceBySimple(getByTax(annualDividendData?.unPaidTax)),
         thisMonthDividend: getPriceByTaxWithSimple(
           annualDividendData.thisMonthDividend,
         ),

--- a/hook/useQueryHook/useAnnualDividendQuery.ts
+++ b/hook/useQueryHook/useAnnualDividendQuery.ts
@@ -35,6 +35,27 @@ export const useAnnualDividendQuery = () => {
   });
 };
 
+export const useAnnualDividendKRQuery = () => {
+  const queryClient = useQueryClient();
+
+  const { modeData } = useControlMode();
+  const { taxData } = useControlTax();
+
+  return useQuery({
+    queryKey: queryKeys.annualDividendKR(),
+    queryFn: dividendAPI.getAnnualDividend,
+    staleTime: 1000 * 5,
+    onSuccess: () => {
+      queryClient.invalidateQueries(
+        queryKeys.annualDividendKR(null, taxData.isTax),
+      );
+      queryClient.invalidateQueries(
+        queryKeys.annualDividendKR(modeData.isSimple, taxData.isTax),
+      );
+    },
+  });
+};
+
 export const useAnnualDividendExchangeQuery = () => {
   const queryClient = useQueryClient();
   const { exchangeRate } = useExchangeRate();
@@ -132,6 +153,100 @@ export const useAnnualDividendExchangeWithSimpleQuery = () => {
 
   return useQuery(
     queryKeys.annualDividend(modeData.isSimple, exchangeRate, taxData.isTax),
+    getQueryFunction,
+  );
+};
+
+export const useAnnualDividendTaxKRQuery = () => {
+  const queryClient = useQueryClient();
+  const { exchangeRate } = useExchangeRate();
+  const { taxData } = useControlTax();
+
+  const { divideByTax, getPriceByTax, getTaxByPrice } = useFormatPrice();
+
+  const getQueryFunction = () => {
+    const annualDividendFullData:
+      | ResponseSuccess<AnnualDividendModel>
+      | undefined = queryClient.getQueryData(queryKeys.annualDividendKR());
+
+    const annualDividendData = annualDividendFullData?.data;
+
+    if (annualDividendData && exchangeRate) {
+      const newMonthlyDividends = Object.entries(
+        annualDividendData.monthlyDividends,
+      ).reduce(
+        (acc, [key, value]) => ({
+          ...acc,
+          [key]: taxData.isTax
+            ? divideByTax(value * exchangeRate)
+            : value * exchangeRate,
+        }),
+        {},
+      );
+
+      return {
+        ...annualDividendData,
+        dividendChange: getPriceByTax(annualDividendData.dividendChange),
+        monthlyDividends: newMonthlyDividends,
+        annualDividend: getPriceByTax(annualDividendData.annualDividend),
+        paidTax: getTaxByPrice(annualDividendData.paidTax),
+        unPaidTax: getTaxByPrice(annualDividendData.unPaidTax),
+        thisMonthDividend: getPriceByTax(annualDividendData.thisMonthDividend),
+      };
+    }
+  };
+
+  return useQuery(
+    queryKeys.annualDividendKR(null, taxData.isTax),
+    getQueryFunction,
+  );
+};
+
+export const useAnnualDividendSimpleKRQuery = () => {
+  const queryClient = useQueryClient();
+  const { modeData } = useControlMode();
+  const { taxData } = useControlTax();
+  const { divideByTax, getPriceByTaxWithSimple, getTaxByPriceWithSimple } =
+    useFormatPrice();
+
+  const getQueryFunction = () => {
+    const annualDividendFullData:
+      | ResponseSuccess<AnnualDividendModel>
+      | undefined = queryClient.getQueryData(queryKeys.annualDividendKR());
+
+    const annualDividendData = annualDividendFullData?.data;
+
+    if (annualDividendData) {
+      const newMonthlyDividends = Object.entries(
+        annualDividendData.monthlyDividends,
+      ).reduce(
+        (acc, [key, value]) => ({
+          ...acc,
+          [key]: taxData.isTax ? divideByTax(value) : value,
+        }),
+        {},
+      );
+
+      return {
+        ...annualDividendData,
+        dividendChange: getPriceByTaxWithSimple(
+          annualDividendData.dividendChange,
+        ),
+        monthlyDividends: newMonthlyDividends,
+        annualDividend: getPriceByTaxWithSimple(
+          annualDividendData.annualDividend,
+        ),
+        paidTax: getTaxByPriceWithSimple(annualDividendData.paidTax),
+        unPaidTax: getTaxByPriceWithSimple(annualDividendData.unPaidTax),
+        thisMonthDividend: getPriceByTaxWithSimple(
+          annualDividendData.thisMonthDividend,
+        ),
+      };
+    }
+  };
+
+  return useQuery(
+    queryKeys.annualDividendKR(modeData.isSimple, taxData.isTax),
     getQueryFunction,
   );
 };

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,7 +1,73 @@
 import {
   getShortCurrencyKRByPlusNumber,
+  getShortCurrencyKRByMinusNumber,
   getShortCurrencyDividendChartKR,
 } from '../components/Chart/utils';
+
+describe('get minus number', () => {
+  const MINUS_TWENTY_BULLION = -2000 * 10000 * 100;
+  const MINUS_TWO_BULLION = -2000 * 10000 * 10;
+  const MINUS_TWO_THOUSAND = -2000 * 10000;
+
+  it('0', () => {
+    const result = getShortCurrencyKRByMinusNumber(0);
+    expect(result).toBe('0');
+  });
+
+  it('-200원', () => {
+    const result = getShortCurrencyKRByMinusNumber(-200);
+    expect(result).toBe('-200');
+  });
+
+  it('-2000원', () => {
+    const result = getShortCurrencyKRByMinusNumber(-2000);
+    expect(result).toBe('-2,000');
+  });
+
+  it('-2만원', () => {
+    const result = getShortCurrencyKRByMinusNumber(-2000 * 10);
+    expect(result).toBe('-2만');
+  });
+
+  it('-20만원', () => {
+    const result = getShortCurrencyKRByMinusNumber(-2000 * 100);
+    expect(result).toBe('-20만');
+  });
+
+  it('-200만원', () => {
+    const result = getShortCurrencyKRByMinusNumber(-2000 * 1000);
+    expect(result).toBe('-200만');
+  });
+
+  it('-2000만원', () => {
+    const result = getShortCurrencyKRByMinusNumber(-2000 * 10000);
+    expect(result).toBe('-2000만');
+  });
+
+  it('-2억2000만원', () => {
+    const result = getShortCurrencyKRByMinusNumber(
+      MINUS_TWO_BULLION + MINUS_TWO_THOUSAND,
+    );
+    expect(result).toBe('-2억 2000만');
+  });
+
+  it('-22억2000만원', () => {
+    const result = getShortCurrencyKRByMinusNumber(
+      MINUS_TWENTY_BULLION + MINUS_TWO_BULLION + MINUS_TWO_THOUSAND,
+    );
+    expect(result).toBe('-22억 2000만');
+  });
+
+  it('-222억2000만원', () => {
+    const result = getShortCurrencyKRByMinusNumber(
+      -2000 * 10000 * 1000 +
+        -2000 * 10000 * 100 +
+        -2000 * 10000 * 10 +
+        -2000 * 10000,
+    );
+    expect(result).toBe('-99억');
+  });
+});
 
 describe('getShortCurrencyKRByPlusNumber', () => {
   it('-100', () => {
@@ -73,29 +139,29 @@ describe('getShortCurrencyKRByPlusNumber', () => {
   it('13억3천', () => {
     const result = getShortCurrencyKRByPlusNumber(1330000000);
 
-    expect(result).toBe('13억');
+    expect(result).toBe('13억 3000만');
   });
 
   it('100억 - 1원', () => {
     const result = getShortCurrencyKRByPlusNumber(10000000000 - 1);
 
-    expect(result).toBe('99억');
+    expect(result).toBe('99억 9999만');
   });
 
   it('100억', () => {
     const result = getShortCurrencyKRByPlusNumber(10000000000);
 
-    expect(result).toBe('99억');
+    expect(result).toBe('99억 9999만');
   });
 
   it('133억3천', () => {
     const result = getShortCurrencyKRByPlusNumber(13330000000);
 
-    expect(result).toBe('99억');
+    expect(result).toBe('99억 9999만');
   });
 });
 
-describe('getShortCurrencyKRByPlusNumber', () => {
+describe('getShortCurrencyDividendChartKR', () => {
   it('-100', () => {
     const result = getShortCurrencyDividendChartKR(-100);
 


### PR DESCRIPTION

### 소득세 클릭에 의한 변화
1. 소득세를 클릭 했을 경우에만 _납부한 세금_, _납부할 세금_ 을 보여준다.
2. 소득세를 클릭 했을 경우에 배당금만 15%를 제외하고 _납부한 세금_, _납부할 세금_ 은 소득세 클릭에 관계없이 항상 보여준다.

현재 종우님과 저는 1번으로 이해를 하여 커밋을 한 상태입니다. 그러나 승권님은 2번을 고려해여 기획과 디자인을 하셨다고하여 우선 1번 작업에 대한 커밋을 revert를 통해 커밋 기록은 유지시키고 반영은 하지않으려고 합니다.

### 기타 작업
- 음수(0보다 작은 수) 를 처리하는 util function 추가
